### PR TITLE
refactor(auth): switch to cookie-based authentication

### DIFF
--- a/src/Redux/Sagas/MainAction.js
+++ b/src/Redux/Sagas/MainAction.js
@@ -23,8 +23,8 @@ export function* API_spCallServer(action) {
         yield put({ type: mainTypes.LOADING_SUCCESS, payload: true });
 
         //set token
-        const token = localStorage.getItem('token');
-        setToken(token);
+        // const token = localStorage.getItem('token');
+        // setToken(token);
 
         /// catch api die
         yield delay(300);
@@ -55,7 +55,7 @@ export function* API_spCallServer(action) {
             // Xử lý token hết hạn
             const login = localStorage.getItem('login');
             if (login !== '') {
-              localStorage.setItem('token', '');
+            //   localStorage.setItem('token', '');
               localStorage.setItem('CustomerID', '');
               localStorage.setItem('GroupInfo', '');
               localStorage.setItem('login', '');
@@ -88,9 +88,8 @@ export function* API_Login(action) {
       // check call api success
     //   if (respone && respone.status === 200) {
       if (respone && respone.status === 200) {
-        console.log(respone.data);
         respone.data.Status === 'False' ? action.resolve([]) : action.resolve(JSON.parse(respone.data.data))
-        localStorage.setItem('token', respone.data.token);
+        // localStorage.setItem('token', respone.data.token);
         yield put({ type: mainTypes.LOADING_SUCCESS, payload: false });
         
       } else {

--- a/src/Services/Api.js
+++ b/src/Services/Api.js
@@ -23,9 +23,10 @@ export const api = Axios.create({
   baseURL: API_END_POINT,
   headers: {
     "Content-Type": "application/json",
-    "Access-Control-Allow-Origin": "http://localhost:3000/",
-    allowedHeaders: ["Content-Type", "Authorization"],
+    // "Access-Control-Allow-Origin": "http://localhost:3000/",
+    // allowedHeaders: ["Content-Type", "Authorization"],
   },
+  withCredentials: true,
 });
 
 export const setToken = (token) => {
@@ -41,30 +42,31 @@ export const authApi = Axios.create({
   baseURL: API_END_POINT,
   headers: {
     "Content-Type": "application/json",
-    "Access-Control-Allow-Origin": "http://localhost:3000/",
+    // "Access-Control-Allow-Origin": "http://localhost:3000/",
   },
+  withCredentials: true,
 });
 
-authApi.interceptors.request.use(async (config) => {
-  console.log("🔥 API INTERCEPTOR TRIGGERED", config.url);
-  const method = config.method?.toUpperCase() || "GET";
-  const timestamp = new Date().toISOString();
-  const url = config.url;
-  const body = config.data ? JSON.stringify(config.data) : "";
+// authApi.interceptors.request.use(async (config) => {
+//   console.log("🔥 API INTERCEPTOR TRIGGERED", config.url);
+//   const method = config.method?.toUpperCase() || "GET";
+//   const timestamp = new Date().toISOString();
+//   const url = config.url;
+//   const body = config.data ? JSON.stringify(config.data) : "";
 
-  // const sessionKey = await getSessionKey();
-  const sessionKey = localStorage.getItem('token');
-  const signdata = `${method}${url}${timestamp}${body}`;
-  console.log(signdata);
+//   // const sessionKey = await getSessionKey();
+//   const sessionKey = localStorage.getItem('token');
+//   const signdata = `${method}${url}${timestamp}${body}`;
+//   console.log(signdata);
 
-  const encoder = new TextEncoder();
+//   const encoder = new TextEncoder();
   
-  const key = await crypto.subtle.importKey('raw', encoder.encode(sessionKey), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
-  const sign = await crypto.subtle.sign('HMAC', key, encoder.encode(signdata));
-  const signature = btoa(String.fromCharCode(...new Uint8Array(sign)));
+//   const key = await crypto.subtle.importKey('raw', encoder.encode(sessionKey), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+//   const sign = await crypto.subtle.sign('HMAC', key, encoder.encode(signdata));
+//   const signature = btoa(String.fromCharCode(...new Uint8Array(sign)));
 
-  config.headers["X-Timestamp"] = timestamp;
-  config.headers["X-Signature"] = signature;
+//   config.headers["X-Timestamp"] = timestamp;
+//   config.headers["X-Signature"] = signature;
 
-  return config;
-});
+//   return config;
+// });


### PR DESCRIPTION
Removes manual token handling in localStorage and client-side request signing. The application now relies on the browser to manage authentication via cookies set by the server.

This change simplifies the client-side authentication flow and improves security by allowing the use of HttpOnly cookies. The `withCredentials` option has been enabled on Axios instances to support sending cookies with requests.

BREAKING CHANGE: The client no longer sends `X-Signature` and `X-Timestamp` headers. The API must now use cookie-based sessions for authentication instead of the previous token signature scheme.